### PR TITLE
Custom result type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["api-bindings"]
 [dependencies]
 reqwest = "0.9"
 serde = { version = "1", features = ["derive"] }
+thiserror = "1.0.25"
 
 [dev-dependencies]
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["api-bindings"]
 [dependencies]
 reqwest = "0.9"
 serde = { version = "1", features = ["derive"] }
-thiserror = "1.0.25"
 
 [dev-dependencies]
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 use std::time::Duration;
 
 use reqwest::{self, Client};
-use result::Result;
+use crate::result::Result;
 
 pub mod result;
 pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,9 @@
 use std::time::Duration;
 
 use reqwest::{self, Client};
+use result::Result;
 
+pub mod result;
 pub mod types;
 
 static API_BASE_URL: &str = "https://hacker-news.firebaseio.com/v0";
@@ -46,9 +48,8 @@ pub struct HnClient {
 }
 
 impl HnClient {
-
     /// Create a new `HnClient` instance.
-    pub fn init() -> reqwest::Result<Self> {
+    pub fn init() -> Result<Self> {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
             .build()?;
@@ -58,57 +59,96 @@ impl HnClient {
     /// Return the item with the specified id.
     ///
     /// May return `None` if item id is invalid.
-    pub fn get_item(&self, id: u32) -> reqwest::Result<Option<types::Item>> {
-        self.client.get(&format!("{}/item/{}.json", API_BASE_URL, id)).send()?.json()
+    pub fn get_item(&self, id: u32) -> Result<Option<types::Item>> {
+        Ok(self
+            .client
+            .get(&format!("{}/item/{}.json", API_BASE_URL, id))
+            .send()?
+            .json()?)
     }
 
     /// Return the user with the specified username.
     ///
     /// May return `None` if username is invalid.
-    pub fn get_user(&self, username: &str) -> reqwest::Result<Option<types::User>> {
-        self.client.get(&format!("{}/user/{}.json", API_BASE_URL, username)).send()?.json()
+    pub fn get_user(&self, username: &str) -> Result<Option<types::User>> {
+        Ok(self
+            .client
+            .get(&format!("{}/user/{}.json", API_BASE_URL, username))
+            .send()?
+            .json()?)
     }
 
     /// Return the id of the newest item.
     ///
     /// To get the 10 latest items, you can decrement the id 10 times.
-    pub fn get_max_item_id(&self) -> reqwest::Result<u32> {
-        self.client.get(&format!("{}/maxitem.json", API_BASE_URL)).send()?.json()
+    pub fn get_max_item_id(&self) -> Result<u32> {
+        Ok(self
+            .client
+            .get(&format!("{}/maxitem.json", API_BASE_URL))
+            .send()?
+            .json()?)
     }
 
     /// Return a list of top story item ids.
-    pub fn get_top_stories(&self) -> reqwest::Result<Vec<u32>> {
-        self.client.get(&format!("{}/topstories.json", API_BASE_URL)).send()?.json()
+    pub fn get_top_stories(&self) -> Result<Vec<u32>> {
+        Ok(self
+            .client
+            .get(&format!("{}/topstories.json", API_BASE_URL))
+            .send()?
+            .json()?)
     }
 
     /// Return a list of new story item ids.
-    pub fn get_new_stories(&self) -> reqwest::Result<Vec<u32>> {
-        self.client.get(&format!("{}/newstories.json", API_BASE_URL)).send()?.json()
+    pub fn get_new_stories(&self) -> Result<Vec<u32>> {
+        Ok(self
+            .client
+            .get(&format!("{}/newstories.json", API_BASE_URL))
+            .send()?
+            .json()?)
     }
 
     /// Return a list of best story item ids.
-    pub fn get_best_stories(&self) -> reqwest::Result<Vec<u32>> {
-        self.client.get(&format!("{}/beststories.json", API_BASE_URL)).send()?.json()
+    pub fn get_best_stories(&self) -> Result<Vec<u32>> {
+        Ok(self
+            .client
+            .get(&format!("{}/beststories.json", API_BASE_URL))
+            .send()?
+            .json()?)
     }
 
     /// Return up to 200 latest Ask HN story item ids.
-    pub fn get_ask_stories(&self) -> reqwest::Result<Vec<u32>> {
-        self.client.get(&format!("{}/askstories.json", API_BASE_URL)).send()?.json()
+    pub fn get_ask_stories(&self) -> Result<Vec<u32>> {
+        Ok(self
+            .client
+            .get(&format!("{}/askstories.json", API_BASE_URL))
+            .send()?
+            .json()?)
     }
 
     /// Return up to 200 latest Show HN story item ids.
-    pub fn get_show_stories(&self) -> reqwest::Result<Vec<u32>> {
-        self.client.get(&format!("{}/showstories.json", API_BASE_URL)).send()?.json()
+    pub fn get_show_stories(&self) -> Result<Vec<u32>> {
+        Ok(self
+            .client
+            .get(&format!("{}/showstories.json", API_BASE_URL))
+            .send()?
+            .json()?)
     }
 
     /// Return up to 200 latest Job story item ids.
-    pub fn get_job_stories(&self) -> reqwest::Result<Vec<u32>> {
-        self.client.get(&format!("{}/jobstories.json", API_BASE_URL)).send()?.json()
+    pub fn get_job_stories(&self) -> Result<Vec<u32>> {
+        Ok(self
+            .client
+            .get(&format!("{}/jobstories.json", API_BASE_URL))
+            .send()?
+            .json()?)
     }
 
     /// Return a list of items and users that have been updated recently.
-    pub fn get_updates(&self) -> reqwest::Result<types::Updates> {
-        self.client.get(&format!("{}/updates.json", API_BASE_URL)).send()?.json()
+    pub fn get_updates(&self) -> Result<types::Updates> {
+        Ok(self
+            .client
+            .get(&format!("{}/updates.json", API_BASE_URL))
+            .send()?
+            .json()?)
     }
-
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,14 @@
+//! Results
+
+use thiserror::Error;
+
+/// Result
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error
+#[derive(Error, Debug)]
+pub enum Error {
+    /// ReqwestError
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+}

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,14 +1,17 @@
 //! Errors, type aliases, and functions related to working with `Result`.
 
-use thiserror::Error;
-
 /// Result
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Represents all the ways that a request can fail.
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum Error {
     /// ReqwestError
-    #[error(transparent)]
-    ReqwestError(#[from] reqwest::Error),
+    ReqwestError(reqwest::Error),
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Self::ReqwestError(err)
+    }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,11 +1,11 @@
-//! Results
+//! Errors, type aliases, and functions related to working with `Result`.
 
 use thiserror::Error;
 
 /// Result
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Error
+/// Represents all the ways that a request can fail.
 #[derive(Error, Debug)]
 pub enum Error {
     /// ReqwestError

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,7 +25,7 @@ impl Item {
         match self {
             Item::Story(story) => story.id,
             Item::Comment(comment) => comment.id,
-            Item::Job(job) =>job.id,
+            Item::Job(job) => job.id,
             Item::Poll(poll) => poll.id,
             Item::Pollopt(pollopt) => pollopt.id,
         }
@@ -283,5 +283,4 @@ mod tests {
         let _pollopt: Pollopt = serde_json::from_str(&json).unwrap();
         let _item: Item = serde_json::from_str(&json).unwrap();
     }
-
 }


### PR DESCRIPTION
This PR adds a custom result type (https://github.com/dbrgn/hn_api/issues/1). It looks like `reqwest::Error` includes handling for `serde_json` errors, so nothing new is added in this PR for separating reqwest and serde errors. 